### PR TITLE
docs: fix the customCommands format in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ bunx @m7medvision/lazycommit@latest config
 
 set up with your openai api key & preferred model:
 
-
 ## usage
 
 You can specify custom templates. use `bunx @m7medvision/lazycommit@latest config` to edit the templates.
@@ -30,18 +29,18 @@ insert the following custom command into your [lazygit](https://github.com/jesse
 
 ```yaml
 customCommands:
-    - key: "<c-a>" # ctrl + a
-        description: "pick AI commit"
-        command: 'git commit -m "{{.Form.Msg}}"'
-        context: "files"
-        prompts:
-            - type: "menuFromCommand"
-            title: "ai Commits"
-            key: "Msg"
-            command: "bunx @m7medvision/lazycommit@latest"
-            filter: '^(?P<number>\d+)\.\s(?P<message>.+)$'
-            valueFormat: "{{ .message }}"
-            labelFormat: "{{ .number }}: {{ .message | green }}"
+  - key: "<c-a>" # ctrl + a
+    description: "pick AI commit"
+    command: 'git commit -m "{{.Form.Msg}}"'
+    context: "files"
+    prompts:
+      - type: "menuFromCommand"
+        title: "ai Commits"
+        key: "Msg"
+        command: "bunx @m7medvision/lazycommit@latest"
+        filter: '^(?P<number>\d+)\.\s(?P<message>.+)$'
+        valueFormat: "{{ .message }}"
+        labelFormat: "{{ .number }}: {{ .message | green }}"
 ```
 
 ### with vim
@@ -52,23 +51,24 @@ abort comitting by deleting the commit message in vim.
 
 ```yaml
 customCommands:
-    - key: "<c-a>" # ctrl + a
-      description: "Pick AI commit"
-      command: 'echo "{{.Form.Msg}}" > .git/COMMIT_EDITMSG && vim .git/COMMIT_EDITMSG && [ -s .git/COMMIT_EDITMSG ] && git commit -F .git/COMMIT_EDITMSG || echo "Commit message is empty, commit aborted."'
-      context: "files"
-      subprocess: true
-      prompts:
-          - type: "menuFromCommand"
-            title: "AI Commits"
-            key: "Msg"
-            command: "bunx @m7medvision/lazycommit@latest"
-            filter: '^(?P<number>\d+)\.\s(?P<message>.+)$'
-            valueFormat: "{{ .message }}"
-            labelFormat: "{{ .number }}: {{ .message | green }}"
+  - key: "<c-a>" # ctrl + a
+    description: "Pick AI commit"
+    command: 'echo "{{.Form.Msg}}" > .git/COMMIT_EDITMSG && vim .git/COMMIT_EDITMSG && [ -s .git/COMMIT_EDITMSG ] && git commit -F .git/COMMIT_EDITMSG || echo "Commit message is empty, commit aborted."'
+    context: "files"
+    subprocess: true
+    prompts:
+      - type: "menuFromCommand"
+        title: "AI Commits"
+        key: "Msg"
+        command: "bunx @m7medvision/lazycommit@latest"
+        filter: '^(?P<number>\d+)\.\s(?P<message>.+)$'
+        valueFormat: "{{ .message }}"
+        labelFormat: "{{ .number }}: {{ .message | green }}"
 ```
 
 ## acknowledgements
-- check out original project [bunnai](https://github.com/chhoumann/bunnai). 
-check out these other projects that inspired this one:
 
--  https://github.com/BuilderIO/ai-shell
+- check out original project [bunnai](https://github.com/chhoumann/bunnai).
+  check out these other projects that inspired this one:
+
+- https://github.com/BuilderIO/ai-shell


### PR DESCRIPTION
Errors in YAML indentation will result in the configuration file being unable to be parsed accurately.