### PR TITLE
feat: integrate opencode CLI provider with automatic model fallback a…

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ AI-powered Git commit message generator that analyzes your staged changes and ou
 
 - Generates configurable number of commit message suggestions from your staged diff
 -  Generates 10 pull request titles based on the diff between the current branch and a target branch
-- Providers: GitHub Copilot (default), OpenAI, Anthropic (Claude Code CLI)
+- Providers: opencode (default, free models), GitHub Copilot, OpenAI, Anthropic (Claude Code CLI), Gemini CLI
 - Multi-language support: Any language (English, Arabic, Korean, etc.)
 - Interactive config to pick provider/model/language and set keys
 - Simple output suitable for piping into TUI menus (one message per line)
@@ -21,6 +21,8 @@ AI-powered Git commit message generator that analyzes your staged changes and ou
 ```bash
 go install github.com/m7medvision/lazycommit@latest
 ```
+
+The default provider is `opencode`, so install and authenticate the `opencode` CLI before running `lazycommit commit`.
 
 Or build from source:
 
@@ -80,8 +82,16 @@ lazycommit uses a two-file configuration system to separate sensitive provider s
 Contains API keys, tokens, and provider-specific settings. **Do not share this file.**
 
 ```yaml
-active_provider: copilot # default if a GitHub token is found
+active_provider: opencode # default; uses opencode CLI free models
 providers:
+  opencode:
+    model: "opencode/minimax-m2.5-free" # Uses opencode CLI - no API key needed
+    fallback_models:
+      - "opencode/minimax-m2.5-free"
+      - "opencode/linng-2.6-flash-free"
+      - "opencode/hy3-preview-free"
+      - "opencode/nemotron-3-super-free"
+    num_suggestions: 10
   copilot:
     api_key: "$GITHUB_TOKEN"   # Uses GitHub token; token is exchanged internally
     model: "gpt-4o"            # or "openai/gpt-4o"; both accepted
@@ -264,6 +274,7 @@ If you are using Commitizen with Lazygit, you can add this custom command:
 ## Troubleshooting
 
 - "No staged changes to commit." — run `git add` first.
+- "opencode CLI not found" — install `opencode` or switch providers with `lazycommit config set`.
 - "API key not set" — set the appropriate key in `.lazycommit.yaml` or env var and rerun.
 - Copilot errors about token exchange — ensure your GitHub token has models scope or is valid; try setting `GITHUB_TOKEN`.
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ providers:
     model: "opencode/minimax-m2.5-free" # Uses opencode CLI - no API key needed
     fallback_models:
       - "opencode/minimax-m2.5-free"
-      - "opencode/linng-2.6-flash-free"
+      - "opencode/ling-2.6-flash-free"
       - "opencode/hy3-preview-free"
       - "opencode/nemotron-3-super-free"
     num_suggestions: 10

--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -41,9 +41,9 @@ var commitCmd = &cobra.Command{
 
 		providerName := config.GetProvider()
 
-		// API key is not needed for anthropic provider (uses CLI)
+		// API keys are not needed for CLI-backed providers.
 		var apiKey string
-		if providerName != "anthropic" {
+		if providerName != "anthropic" && providerName != "gemini" && providerName != "opencode" {
 			var err error
 			apiKey, err = config.GetAPIKey()
 			if err != nil {
@@ -53,7 +53,7 @@ var commitCmd = &cobra.Command{
 		}
 
 		var model string
-		if providerName == "copilot" || providerName == "openai" || providerName == "anthropic" {
+		if providerName == "copilot" || providerName == "openai" || providerName == "anthropic" || providerName == "gemini" || providerName == "opencode" {
 			var err error
 			model, err = config.GetModel()
 			if err != nil {
@@ -86,6 +86,12 @@ var commitCmd = &cobra.Command{
 				numSuggestions = 10
 			}
 			aiProvider = provider.NewGeminiProvider(model, numSuggestions)
+		case "opencode":
+			numSuggestions := config.GetNumSuggestions()
+			if numSuggestions <= 0 {
+				numSuggestions = 10
+			}
+			aiProvider = provider.NewOpencodeProvider(model, config.GetFallbackModels(), numSuggestions)
 		default:
 			// Default to copilot if provider is not set or unknown
 			aiProvider = provider.NewCopilotProvider(apiKey, endpoint)

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -81,7 +81,7 @@ func runInteractiveConfig() {
 
 	providerPrompt := &survey.Select{
 		Message: "Choose a provider:",
-		Options: []string{"openai", "copilot", "anthropic", "gemini"},
+		Options: []string{"opencode", "openai", "copilot", "anthropic", "gemini"},
 		Default: currentProvider,
 	}
 	var selectedProvider string
@@ -152,8 +152,8 @@ func runInteractiveConfig() {
 		fmt.Printf("Language set to: %s\n", langValue)
 	}
 
-	// API key configuration - skip for copilot, anthropic and gemini
-	if selectedProvider != "copilot" && selectedProvider != "anthropic" && selectedProvider != "gemini" {
+	// API key configuration - skip for CLI-backed providers and copilot token exchange.
+	if selectedProvider != "copilot" && selectedProvider != "anthropic" && selectedProvider != "gemini" && selectedProvider != "opencode" {
 		apiKeyPrompt := &survey.Input{
 			Message: fmt.Sprintf("Enter API Key for %s:", selectedProvider),
 		}
@@ -175,6 +175,8 @@ func runInteractiveConfig() {
 		fmt.Println("Anthropic provider uses Claude Code CLI - no API key needed.")
 	} else if selectedProvider == "gemini" {
 		fmt.Println("Gemini provider uses Gemini CLI - no API key needed.")
+	} else if selectedProvider == "opencode" {
+		fmt.Println("opencode provider uses opencode CLI - no API key needed.")
 	}
 
 	availableModels := map[string][]string{
@@ -182,6 +184,7 @@ func runInteractiveConfig() {
 		"copilot":   {},
 		"anthropic": {},
 		"gemini":    {},
+		"opencode":  {},
 	}
 
 	modelDisplayToID := map[string]string{}
@@ -222,6 +225,12 @@ func runInteractiveConfig() {
 			availableModels["gemini"] = append(availableModels["gemini"], display)
 			modelDisplayToID[display] = m.APIModel
 		}
+	case "opencode":
+		for _, m := range models.OpencodeModels {
+			display := fmt.Sprintf("%s (%s)", m.Name, m.APIModel)
+			availableModels["opencode"] = append(availableModels["opencode"], display)
+			modelDisplayToID[display] = m.APIModel
+		}
 	}
 
 	modelPrompt := &survey.Select{
@@ -232,7 +241,7 @@ func runInteractiveConfig() {
 	// Try to set the default to the current model if possible
 	isValidDefault := false
 	currentDisplay := ""
-	if selectedProvider == "openai" || selectedProvider == "anthropic" || selectedProvider == "copilot" || selectedProvider == "gemini" {
+	if selectedProvider == "openai" || selectedProvider == "anthropic" || selectedProvider == "copilot" || selectedProvider == "gemini" || selectedProvider == "opencode" {
 		for display, id := range modelDisplayToID {
 			if id == currentModel || display == currentModel {
 				isValidDefault = true
@@ -261,7 +270,7 @@ func runInteractiveConfig() {
 	}
 
 	selectedModel := selectedDisplay
-	if selectedProvider == "openai" || selectedProvider == "anthropic" || selectedProvider == "copilot" || selectedProvider == "gemini" {
+	if selectedProvider == "openai" || selectedProvider == "anthropic" || selectedProvider == "copilot" || selectedProvider == "gemini" || selectedProvider == "opencode" {
 		selectedModel = modelDisplayToID[selectedDisplay]
 	}
 
@@ -274,8 +283,8 @@ func runInteractiveConfig() {
 		fmt.Printf("Model set to: %s\n", selectedModel)
 	}
 
-	// Number of suggestions configuration for anthropic and gemini
-	if selectedProvider == "anthropic" || selectedProvider == "gemini" {
+	// Number of suggestions configuration for CLI-backed providers.
+	if selectedProvider == "anthropic" || selectedProvider == "gemini" || selectedProvider == "opencode" {
 		numSuggestionsPrompt := &survey.Input{
 			Message: "Number of commit message suggestions (default: 10):",
 			Default: "10",
@@ -299,8 +308,8 @@ func runInteractiveConfig() {
 	// Get current endpoint
 	currentEndpoint, _ := config.GetEndpoint()
 
-	// Endpoint configuration prompt - skip for anthropic and gemini since they use CLI
-	if selectedProvider != "anthropic" && selectedProvider != "gemini" {
+	// Endpoint configuration prompt - skip CLI-backed providers.
+	if selectedProvider != "anthropic" && selectedProvider != "gemini" && selectedProvider != "opencode" {
 		endpointPrompt := &survey.Input{
 			Message: "Enter custom endpoint URL (leave empty for default):",
 			Default: currentEndpoint,

--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -51,9 +51,9 @@ var prCmd = &cobra.Command{
 
 		providerName := config.GetProvider()
 
-		// API key is not needed for anthropic provider (uses CLI)
+		// API keys are not needed for CLI-backed providers.
 		var apiKey string
-		if providerName != "anthropic" {
+		if providerName != "anthropic" && providerName != "gemini" && providerName != "opencode" {
 			var err error
 			apiKey, err = config.GetAPIKey()
 			if err != nil {
@@ -63,7 +63,7 @@ var prCmd = &cobra.Command{
 		}
 
 		var model string
-		if providerName == "copilot" || providerName == "openai" || providerName == "anthropic" {
+		if providerName == "copilot" || providerName == "openai" || providerName == "anthropic" || providerName == "gemini" || providerName == "opencode" {
 			var err error
 			model, err = config.GetModel()
 			if err != nil {
@@ -90,6 +90,9 @@ var prCmd = &cobra.Command{
 		case "gemini":
 			numSuggestions := config.GetNumSuggestions()
 			aiProvider = provider.NewGeminiProvider(model, numSuggestions)
+		case "opencode":
+			numSuggestions := config.GetNumSuggestions()
+			aiProvider = provider.NewOpencodeProvider(model, config.GetFallbackModels(), numSuggestions)
 		default:
 			// Default to copilot if provider is not set or unknown
 			aiProvider = provider.NewCopilotProvider(apiKey, endpoint)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,10 +14,11 @@ import (
 )
 
 type ProviderConfig struct {
-	APIKey         string `mapstructure:"api_key"`
-	Model          string `mapstructure:"model"`
-	EndpointURL    string `mapstructure:"endpoint_url"`
-	NumSuggestions int    `mapstructure:"num_suggestions"`
+	APIKey         string   `mapstructure:"api_key"`
+	Model          string   `mapstructure:"model"`
+	EndpointURL    string   `mapstructure:"endpoint_url"`
+	NumSuggestions int      `mapstructure:"num_suggestions"`
+	FallbackModels []string `mapstructure:"fallback_models"`
 }
 
 type Config struct {
@@ -34,15 +35,22 @@ func InitConfig() {
 
 	viper.SetConfigFile(filepath.Join(getConfigDir(), ".lazycommit.yaml"))
 
+	viper.SetDefault("active_provider", "opencode")
+	viper.SetDefault("providers.opencode.model", "opencode/minimax-m2.5-free")
+	viper.SetDefault("providers.opencode.fallback_models", []string{
+		"opencode/minimax-m2.5-free",
+		"opencode/ling-2.6-flash-free",
+		"opencode/hy3-preview-free",
+		"opencode/nemotron-3-super-free",
+	})
+	viper.SetDefault("providers.opencode.num_suggestions", 10)
+
 	if token, err := LoadGitHubToken(); err == nil && token != "" {
-		viper.SetDefault("active_provider", "copilot")
 		viper.SetDefault("providers.copilot.api_key", token)
-		viper.SetDefault("providers.copilot.model", "openai/gpt-5-mini")
-	} else {
-		viper.SetDefault("active_provider", "openai")
-		viper.SetDefault("providers.openai.model", "openai/gpt-5-mini")
 	}
 
+	viper.SetDefault("providers.copilot.model", "openai/gpt-5-mini")
+	viper.SetDefault("providers.openai.model", "openai/gpt-5-mini")
 	viper.SetDefault("providers.anthropic.model", "claude-haiku-4-5")
 	viper.SetDefault("providers.anthropic.num_suggestions", 10)
 	viper.SetDefault("providers.gemini.model", "flash")
@@ -153,6 +161,8 @@ func GetEndpoint() (string, error) {
 		return "", nil // Anthropic uses CLI, no endpoint needed
 	case "gemini":
 		return "", nil // Gemini uses CLI, no endpoint needed
+	case "opencode":
+		return "", nil // opencode uses CLI, no endpoint needed
 	default:
 		return "", fmt.Errorf("no default endpoint available for provider '%s'", cfg.ActiveProvider)
 	}
@@ -278,6 +288,17 @@ func GetNumSuggestions() int {
 		return 10 // Default to 10 if not set or invalid
 	}
 	return providerConfig.NumSuggestions
+}
+
+func GetFallbackModels() []string {
+	if cfg == nil {
+		InitConfig()
+	}
+	providerConfig, err := GetActiveProviderConfig()
+	if err != nil {
+		return nil
+	}
+	return providerConfig.FallbackModels
 }
 
 func SetNumSuggestions(provider, numSuggestions string) error {

--- a/internal/provider/models/models.go
+++ b/internal/provider/models/models.go
@@ -26,6 +26,7 @@ const (
 	ProviderOpenAI    ModelProvider = "openai"
 	ProviderAnthropic ModelProvider = "anthropic"
 	ProviderGemini    ModelProvider = "gemini"
+	ProviderOpencode  ModelProvider = "opencode"
 
 	GPT41        ModelID = "gpt-4.1"
 	GPT41Mini    ModelID = "gpt-4.1-mini"
@@ -48,6 +49,11 @@ const (
 	GeminiFlashLite ModelID = "flash-lite"
 	Gemini25Pro     ModelID = "gemini-2.5-pro"
 	Gemini25Flash   ModelID = "gemini-2.5-flash"
+
+	OpencodeMinimaxM25Free     ModelID = "opencode/minimax-m2.5-free"
+	OpencodeLing26FlashFree    ModelID = "opencode/ling-2.6-flash-free"
+	OpencodeHy3PreviewFree     ModelID = "opencode/hy3-preview-free"
+	OpencodeNemotron3SuperFree ModelID = "opencode/nemotron-3-super-free"
 )
 
 var OpenAIModels = map[ModelID]Model{
@@ -279,5 +285,32 @@ var GeminiModels = map[ModelID]Model{
 		APIModel:            "gemini-2.5-flash",
 		ContextWindow:       1_000_000,
 		SupportsAttachments: true,
+	},
+}
+
+var OpencodeModels = map[ModelID]Model{
+	OpencodeMinimaxM25Free: {
+		ID:       OpencodeMinimaxM25Free,
+		Name:     "Minimax M2.5 Free",
+		Provider: ProviderOpencode,
+		APIModel: string(OpencodeMinimaxM25Free),
+	},
+	OpencodeLing26FlashFree: {
+		ID:       OpencodeLing26FlashFree,
+		Name:     "Ling 2.6 Flash Free",
+		Provider: ProviderOpencode,
+		APIModel: string(OpencodeLing26FlashFree),
+	},
+	OpencodeHy3PreviewFree: {
+		ID:       OpencodeHy3PreviewFree,
+		Name:     "HY3 Preview Free",
+		Provider: ProviderOpencode,
+		APIModel: string(OpencodeHy3PreviewFree),
+	},
+	OpencodeNemotron3SuperFree: {
+		ID:       OpencodeNemotron3SuperFree,
+		Name:     "Nemotron 3 Super Free",
+		Provider: ProviderOpencode,
+		APIModel: string(OpencodeNemotron3SuperFree),
 	},
 }

--- a/internal/provider/opencode.go
+++ b/internal/provider/opencode.go
@@ -1,0 +1,160 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+const defaultOpencodeModel = "opencode/minimax-m2.5-free"
+
+var defaultOpencodeFallbackModels = []string{
+	"opencode/minimax-m2.5-free",
+	"opencode/ling-2.6-flash-free",
+	"opencode/hy3-preview-free",
+	"opencode/nemotron-3-super-free",
+}
+
+type OpencodeProvider struct {
+	model          string
+	fallbackModels []string
+	numSuggestions int
+}
+
+func NewOpencodeProvider(model string, fallbackModels []string, numSuggestions int) *OpencodeProvider {
+	if strings.TrimSpace(model) == "" {
+		model = defaultOpencodeModel
+	}
+	if len(fallbackModels) == 0 {
+		fallbackModels = defaultOpencodeFallbackModels
+	}
+	if numSuggestions <= 0 {
+		numSuggestions = 10
+	}
+	return &OpencodeProvider{
+		model:          strings.TrimSpace(model),
+		fallbackModels: fallbackModels,
+		numSuggestions: numSuggestions,
+	}
+}
+
+func opencodeModelCandidates(model string, fallbackModels []string) []string {
+	seen := make(map[string]struct{})
+	var candidates []string
+
+	add := func(m string) {
+		m = strings.TrimSpace(m)
+		if m == "" {
+			return
+		}
+		if _, ok := seen[m]; ok {
+			return
+		}
+		seen[m] = struct{}{}
+		candidates = append(candidates, m)
+	}
+
+	add(model)
+	for _, fallback := range fallbackModels {
+		add(fallback)
+	}
+	return candidates
+}
+
+func (o *OpencodeProvider) GenerateCommitMessage(ctx context.Context, diff string) (string, error) {
+	msgs, err := o.GenerateCommitMessages(ctx, diff)
+	if err != nil {
+		return "", err
+	}
+	if len(msgs) == 0 {
+		return "", fmt.Errorf("no commit messages generated")
+	}
+	return msgs[0], nil
+}
+
+func (o *OpencodeProvider) GenerateCommitMessages(ctx context.Context, diff string) ([]string, error) {
+	if strings.TrimSpace(diff) == "" {
+		return nil, fmt.Errorf("no diff provided")
+	}
+
+	systemMsg := GetSystemMessage()
+	userPrompt := GetCommitMessagePrompt(diff)
+	fullPrompt := fmt.Sprintf("%s\n\nUser request: %s\n\nIMPORTANT: Generate exactly %d commit messages, one per line. Do not include any other text, explanations, or formatting - just the commit messages.",
+		systemMsg, userPrompt, o.numSuggestions)
+
+	output, err := o.runCLI(ctx, fullPrompt)
+	if err != nil {
+		return nil, err
+	}
+
+	commitMessages := parseOutputLines(output, o.numSuggestions)
+	if len(commitMessages) == 0 {
+		return nil, fmt.Errorf("no valid commit messages generated from opencode output")
+	}
+
+	return commitMessages, nil
+}
+
+func (o *OpencodeProvider) GeneratePRTitle(ctx context.Context, diff string) (string, error) {
+	titles, err := o.GeneratePRTitles(ctx, diff)
+	if err != nil {
+		return "", err
+	}
+	if len(titles) == 0 {
+		return "", fmt.Errorf("no PR titles generated")
+	}
+	return titles[0], nil
+}
+
+func (o *OpencodeProvider) GeneratePRTitles(ctx context.Context, diff string) ([]string, error) {
+	if strings.TrimSpace(diff) == "" {
+		return nil, fmt.Errorf("no diff provided")
+	}
+
+	systemMsg := GetSystemMessage()
+	userPrompt := GetPRTitlePrompt(diff)
+	fullPrompt := fmt.Sprintf("%s\n\nUser request: %s\n\nIMPORTANT: Generate exactly %d pull request titles, one per line. Do not include any other text, explanations, or formatting - just the PR titles.",
+		systemMsg, userPrompt, o.numSuggestions)
+
+	output, err := o.runCLI(ctx, fullPrompt)
+	if err != nil {
+		return nil, err
+	}
+
+	prTitles := parseOutputLines(output, o.numSuggestions)
+	if len(prTitles) == 0 {
+		return nil, fmt.Errorf("no valid PR titles generated from opencode output")
+	}
+
+	return prTitles, nil
+}
+
+func (o *OpencodeProvider) runCLI(ctx context.Context, prompt string) (string, error) {
+	if _, err := exec.LookPath("opencode"); err != nil {
+		return "", fmt.Errorf("opencode CLI not found in PATH. Please install opencode CLI: %w", err)
+	}
+
+	candidates := opencodeModelCandidates(o.model, o.fallbackModels)
+	var errors []string
+	for _, model := range candidates {
+		cmd := exec.CommandContext(ctx, "opencode", "run", "--model", model, "--", prompt)
+
+		var stdoutBuf, stderrBuf strings.Builder
+		cmd.Stdout = &stdoutBuf
+		cmd.Stderr = &stderrBuf
+
+		if err := cmd.Run(); err != nil {
+			errors = append(errors, fmt.Sprintf("%s: %v: %s", model, err, strings.TrimSpace(stderrBuf.String())))
+			continue
+		}
+
+		output := strings.TrimSpace(stdoutBuf.String())
+		if output != "" {
+			return output, nil
+		}
+		errors = append(errors, fmt.Sprintf("%s: empty output", model))
+	}
+
+	return "", fmt.Errorf("error executing opencode CLI with models %q: %s", candidates, strings.Join(errors, "; "))
+}

--- a/internal/provider/opencode.go
+++ b/internal/provider/opencode.go
@@ -138,14 +138,35 @@ func (o *OpencodeProvider) runCLI(ctx context.Context, prompt string) (string, e
 	candidates := opencodeModelCandidates(o.model, o.fallbackModels)
 	var errors []string
 	for _, model := range candidates {
-		cmd := exec.CommandContext(ctx, "opencode", "run", "--model", model, "--", prompt)
+		cmd := exec.CommandContext(ctx, "opencode", "run", "--model", model)
+
+		stdin, err := cmd.StdinPipe()
+		if err != nil {
+			errors = append(errors, fmt.Sprintf("%s: error creating stdin pipe: %v", model, err))
+			continue
+		}
 
 		var stdoutBuf, stderrBuf strings.Builder
 		cmd.Stdout = &stdoutBuf
 		cmd.Stderr = &stderrBuf
 
-		if err := cmd.Run(); err != nil {
-			errors = append(errors, fmt.Sprintf("%s: %v: %s", model, err, strings.TrimSpace(stderrBuf.String())))
+		if err := cmd.Start(); err != nil {
+			errors = append(errors, fmt.Sprintf("%s: error starting opencode CLI: %v", model, err))
+			continue
+		}
+
+		_, writeErr := stdin.Write([]byte(prompt))
+		stdin.Close()
+
+		waitErr := cmd.Wait()
+
+		if writeErr != nil {
+			errors = append(errors, fmt.Sprintf("%s: error writing to opencode CLI stdin: %v", model, writeErr))
+			continue
+		}
+
+		if waitErr != nil {
+			errors = append(errors, fmt.Sprintf("%s: %v: %s", model, waitErr, strings.TrimSpace(stderrBuf.String())))
 			continue
 		}
 

--- a/internal/provider/opencode_test.go
+++ b/internal/provider/opencode_test.go
@@ -1,0 +1,25 @@
+package provider
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestOpencodeModelCandidates(t *testing.T) {
+	got := opencodeModelCandidates(" opencode/minimax-m2.5-free ", []string{
+		"opencode/minimax-m2.5-free",
+		" opencode/ling-2.6-flash-free ",
+		"",
+		"opencode/hy3-preview-free",
+	})
+
+	want := []string{
+		"opencode/minimax-m2.5-free",
+		"opencode/ling-2.6-flash-free",
+		"opencode/hy3-preview-free",
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
# feat: integrate opencode CLI provider with automatic model fallback and update configuration workflows

## Summary
This PR adds `opencode` as a first-class provider for commit message and PR title generation, makes it the default provider, and updates config and docs to support CLI-based workflows without API keys.

## Main Features
- Added new `opencode` provider integration for both `commit` and `pr` commands.
- Implemented automatic model fallback for `opencode` execution:
  - Tries configured primary model first.
  - Falls back through configured free-model candidates if a model fails.
- Switched default provider to `opencode` in configuration defaults.
- Added provider-level `fallback_models` support in config schema.
- Updated interactive config flow to:
  - Include `opencode` as a selectable provider.
  - Skip API key and endpoint prompts for CLI-backed providers (`anthropic`, `gemini`, `opencode`).
  - Support `opencode` model selection and `num_suggestions`.
- Expanded provider model catalog with `opencode` free model entries.
- Added tests for `opencode` model candidate normalization and deduplication.
- Updated README with:
  - New provider list and default behavior.
  - `opencode` setup guidance and troubleshooting note.

## Files Changed
- `README.md`
- `cmd/commit.go`
- `cmd/config.go`
- `cmd/pr.go`
- `internal/config/config.go`
- `internal/provider/models/models.go`
- `internal/provider/opencode.go`
- `internal/provider/opencode_test.go`

## Why
- Provides a zero-API-key default path using the `opencode` CLI and free models.
- Improves resilience by retrying across fallback models when the first choice fails.
- Aligns configuration UX with CLI-backed provider behavior.

## Notes
- `opencode` CLI must be installed and authenticated for default flow.
- Existing non-CLI providers remain available (`copilot`, `openai`, `anthropic`, `gemini`).
