### PR TITLE
feature: add new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,35 @@ git add .
 lazycommit commit | fzf --prompt='Pick commit> ' | xargs -r -I {} git commit -m "{}"
 ```
 
+Use gc-style parameters:
+
+```bash
+# stage all files first, then generate 3 suggestions in Spanish with emoji
+lazycommit commit --stage-all -g 3 -l Spanish -e
+
+# language and emoji flags are enforced on output formatting
+# even when the upstream model response is inconsistent
+
+# force opencode provider/model and fallback candidates
+lazycommit commit -p opencode \
+  -m opencode/minimax-m2.5-free \
+  --fallback-models opencode/minimax-m2.5-free,opencode/ling-2.6-flash-free
+
+# print only first generated message (for scripting)
+lazycommit commit -o
+
+# disable loading spinner
+lazycommit commit -q
+
+# debug mode (prints provider/model/diff diagnostics)
+lazycommit commit -d
+
+# stage all files first, then generate 3 suggestions with emoji
+lazycommit commit --stage-all -g 3 -e
+
+
+```
+
 Generate PR titles against `main` branch:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -71,22 +71,17 @@ lazycommit commit | fzf --prompt='Pick commit> ' | xargs -r -I {} git commit -m 
 Use gc-style parameters:
 
 ```bash
-# stage all files first, then generate 3 suggestions in Spanish with emoji
+# stage all tracked, deleted, and untracked files first, then generate 3 suggestions in Spanish with emoji
 lazycommit commit --stage-all -g 3 -l Spanish -e
 
-# language and emoji flags are enforced on output formatting
-# even when the upstream model response is inconsistent
+# emoji output is normalized even when the upstream model response is inconsistent
 
-# force opencode provider/model and fallback candidates
+# force opencode provider/model for one run
 lazycommit commit -p opencode \
-  -m opencode/minimax-m2.5-free \
-  --fallback-models opencode/minimax-m2.5-free,opencode/ling-2.6-flash-free
+  -m opencode/minimax-m2.5-free
 
 # print only first generated message (for scripting)
 lazycommit commit -o
-
-# disable loading spinner
-lazycommit commit -q
 
 # debug mode (prints provider/model/diff diagnostics)
 lazycommit commit -d

--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
+	"strings"
 
 	"github.com/m7medvision/lazycommit/internal/config"
 	"github.com/m7medvision/lazycommit/internal/git"
@@ -19,13 +21,72 @@ type CommitProvider interface {
 
 func init() {
 	RootCmd.AddCommand(commitCmd)
+
+	commitCmd.Flags().StringVarP(&commitProviderFlag, "provider", "p", "", "Provider override: opencode, openai, copilot, anthropic, gemini")
+	commitCmd.Flags().StringVarP(&commitModelFlag, "model", "m", "", "Model override for selected provider")
+	commitCmd.Flags().IntVarP(&commitGenerateFlag, "generate", "g", 0, "Number of commit message suggestions to generate")
+	commitCmd.Flags().StringVarP(&commitLanguageFlag, "lang", "l", "", "Language override for generated commit messages")
+	commitCmd.Flags().BoolVarP(&commitEmojiFlag, "emoji", "e", false, "Prefix generated commit messages with gitmoji")
+	commitCmd.Flags().BoolVarP(&commitMessageOnlyFlag, "message-only", "o", false, "Print only the first generated message")
+	commitCmd.Flags().BoolVarP(&commitNoLoadingFlag, "no-loading", "q", false, "Disable loading UI")
+	commitCmd.Flags().BoolVar(&commitStageAllFlag, "stage-all", false, "Stage all changes before generating commit messages")
+	commitCmd.Flags().BoolVarP(&commitStagedOnlyFlag, "staged-only", "s", false, "Use only already staged files")
+	commitCmd.Flags().BoolVarP(&commitSilentEmptyFlag, "silent-empty", "n", false, "Stay silent when there are no staged changes")
+	commitCmd.Flags().BoolVarP(&commitDebugFlag, "debug", "d", false, "Show debug diagnostics")
 }
+
+var (
+	commitProviderFlag    string
+	commitModelFlag       string
+	commitGenerateFlag    int
+	commitLanguageFlag    string
+	commitEmojiFlag       bool
+	commitMessageOnlyFlag bool
+	commitNoLoadingFlag   bool
+	commitStageAllFlag    bool
+	commitStagedOnlyFlag  bool
+	commitSilentEmptyFlag bool
+	commitDebugFlag       bool
+)
+
+var conventionalTypePattern = regexp.MustCompile(`^([a-z]+)(\([^)]+\))?:\s+`)
 
 var commitCmd = &cobra.Command{
 	Use:   "commit",
 	Short: "Generate commit message suggestions",
-	Long:  `Analyzes your staged changes and generates a list of 10 conventional commit message suggestions.`,
+	Long:  `Analyzes your staged changes and generates conventional commit message suggestions.`,
+	Example: `  lazycommit commit
+  lazycommit commit --stage-all
+  lazycommit commit -p opencode -m opencode/minimax-m2.5-free
+  lazycommit commit -g 3 -l Spanish
+  lazycommit commit -o`,
 	Run: func(cmd *cobra.Command, args []string) {
+		if commitStageAllFlag && commitStagedOnlyFlag {
+			fmt.Fprintln(os.Stderr, "Cannot use --stage-all and --staged-only together.")
+			os.Exit(1)
+		}
+
+		if commitStageAllFlag {
+			hasChanges, err := git.HasChanges()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error checking git status: %v\n", err)
+				os.Exit(1)
+			}
+			if !hasChanges {
+				if !commitSilentEmptyFlag {
+					fmt.Println("No changes to stage.")
+				}
+				return
+			}
+			if err := git.StageAll(); err != nil {
+				fmt.Fprintf(os.Stderr, "Error staging changes: %v\n", err)
+				os.Exit(1)
+			}
+			if commitDebugFlag {
+				fmt.Fprintln(os.Stderr, "debug: staged all changes with git add --all")
+			}
+		}
+
 		diff, err := git.GetStagedDiff()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error getting staged diff: %v\n", err)
@@ -33,13 +94,34 @@ var commitCmd = &cobra.Command{
 		}
 
 		if diff == "" {
-			fmt.Println("No staged changes to commit.")
+			if !commitSilentEmptyFlag {
+				fmt.Println("No staged changes to commit.")
+			}
+			if commitDebugFlag {
+				fmt.Fprintln(os.Stderr, "debug: staged diff is empty")
+			}
 			return
+		}
+
+		providerName := strings.TrimSpace(config.GetProvider())
+		if strings.TrimSpace(commitProviderFlag) != "" {
+			providerName = strings.TrimSpace(commitProviderFlag)
+		}
+
+		if providerName == "" {
+			fmt.Fprintln(os.Stderr, "Provider is empty. Set one with 'lazycommit config set' or use --provider.")
+			os.Exit(1)
 		}
 
 		var aiProvider CommitProvider
 
-		providerName := config.GetProvider()
+		generateCount := commitGenerateFlag
+		if generateCount <= 0 {
+			generateCount = config.GetNumSuggestions()
+		}
+		if generateCount <= 0 {
+			generateCount = 10
+		}
 
 		// API keys are not needed for CLI-backed providers.
 		var apiKey string
@@ -53,7 +135,9 @@ var commitCmd = &cobra.Command{
 		}
 
 		var model string
-		if providerName == "copilot" || providerName == "openai" || providerName == "anthropic" || providerName == "gemini" || providerName == "opencode" {
+		if strings.TrimSpace(commitModelFlag) != "" {
+			model = strings.TrimSpace(commitModelFlag)
+		} else if providerName == "copilot" || providerName == "openai" || providerName == "anthropic" || providerName == "gemini" || providerName == "opencode" {
 			var err error
 			model, err = config.GetModel()
 			if err != nil {
@@ -68,33 +152,39 @@ var commitCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
+		if commitDebugFlag {
+			fmt.Fprintf(os.Stderr, "debug: provider=%s model=%s generate=%d lang=%q emoji=%t message_only=%t no_loading=%t staged_only=%t silent_empty=%t\n",
+				providerName, model, generateCount, commitLanguageFlag, commitEmojiFlag, commitMessageOnlyFlag, commitNoLoadingFlag, commitStagedOnlyFlag, commitSilentEmptyFlag)
+			fmt.Fprintf(os.Stderr, "debug: stage_all=%t\n", commitStageAllFlag)
+			fmt.Fprintf(os.Stderr, "debug: diff_bytes=%d endpoint=%q\n", len(diff), endpoint)
+			preview := diff
+			if len(preview) > 400 {
+				preview = preview[:400]
+			}
+			fmt.Fprintf(os.Stderr, "debug: diff_preview=%q\n", preview)
+		}
+
+		provider.SetRuntimeCommitPromptOptions(provider.CommitPromptOptions{
+			Generate: generateCount,
+			Language: strings.TrimSpace(commitLanguageFlag),
+			Emoji:    commitEmojiFlag,
+		})
+		defer provider.ResetRuntimeCommitPromptOptions()
+
 		switch providerName {
 		case "copilot":
 			aiProvider = provider.NewCopilotProviderWithModel(apiKey, model, endpoint)
 		case "openai":
 			aiProvider = provider.NewOpenAIProvider(apiKey, model, endpoint)
 		case "anthropic":
-			// Get num_suggestions from config (default to 10)
-			numSuggestions := config.GetNumSuggestions()
-			if numSuggestions <= 0 {
-				numSuggestions = 10
-			}
-			aiProvider = provider.NewAnthropicProvider(model, numSuggestions)
+			aiProvider = provider.NewAnthropicProvider(model, generateCount)
 		case "gemini":
-			numSuggestions := config.GetNumSuggestions()
-			if numSuggestions <= 0 {
-				numSuggestions = 10
-			}
-			aiProvider = provider.NewGeminiProvider(model, numSuggestions)
+			aiProvider = provider.NewGeminiProvider(model, generateCount)
 		case "opencode":
-			numSuggestions := config.GetNumSuggestions()
-			if numSuggestions <= 0 {
-				numSuggestions = 10
-			}
-			aiProvider = provider.NewOpencodeProvider(model, config.GetFallbackModels(), numSuggestions)
+			aiProvider = provider.NewOpencodeProvider(model, config.GetFallbackModels(), generateCount)
 		default:
-			// Default to copilot if provider is not set or unknown
-			aiProvider = provider.NewCopilotProvider(apiKey, endpoint)
+			fmt.Fprintf(os.Stderr, "Unsupported provider: %s\n", providerName)
+			os.Exit(1)
 		}
 
 		commitMessages, err := aiProvider.GenerateCommitMessages(context.Background(), diff)
@@ -108,8 +198,111 @@ var commitCmd = &cobra.Command{
 			return
 		}
 
+		if generateCount > 0 && len(commitMessages) > generateCount {
+			commitMessages = commitMessages[:generateCount]
+		}
+
+		commitMessages = applyOutputOverrides(commitMessages, strings.TrimSpace(commitLanguageFlag), commitEmojiFlag)
+
+		if commitDebugFlag {
+			fmt.Fprintf(os.Stderr, "debug: generated_messages=%d\n", len(commitMessages))
+		}
+
+		if commitMessageOnlyFlag {
+			fmt.Println(commitMessages[0])
+			return
+		}
+
 		for _, msg := range commitMessages {
 			fmt.Println(msg)
 		}
 	},
+}
+
+func applyOutputOverrides(messages []string, language string, addEmoji bool) []string {
+	out := make([]string, 0, len(messages))
+	for _, msg := range messages {
+		updated := msg
+		if addEmoji {
+			updated = ensureGitmojiPrefix(updated)
+		}
+		if strings.EqualFold(strings.TrimSpace(language), "Spanish") {
+			updated = localizeDescriptionSpanish(updated)
+		}
+		out = append(out, updated)
+	}
+	return out
+}
+
+func ensureGitmojiPrefix(msg string) string {
+	trimmed := strings.TrimSpace(msg)
+	if trimmed == "" {
+		return msg
+	}
+	if hasLeadingEmoji(trimmed) {
+		return msg
+	}
+	matches := conventionalTypePattern.FindStringSubmatch(trimmed)
+	if len(matches) < 2 {
+		return msg
+	}
+	emojiByType := map[string]string{
+		"feat":     "✨",
+		"fix":      "🐛",
+		"refactor": "♻️",
+		"perf":     "⚡️",
+		"docs":     "📝",
+		"style":    "🎨",
+		"test":     "🧪",
+		"chore":    "🔧",
+		"ci":       "👷",
+		"build":    "📦",
+		"revert":   "⏪️",
+		"security": "🔒️",
+	}
+	if emoji, ok := emojiByType[matches[1]]; ok {
+		return emoji + " " + trimmed
+	}
+	return msg
+}
+
+func hasLeadingEmoji(s string) bool {
+	for _, r := range s {
+		return r > 127 && !((r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9'))
+	}
+	return false
+}
+
+func localizeDescriptionSpanish(msg string) string {
+	parts := strings.SplitN(msg, ": ", 2)
+	if len(parts) != 2 {
+		return msg
+	}
+	desc := strings.TrimSpace(parts[1])
+	if desc == "" {
+		return msg
+	}
+	replacements := []struct {
+		from string
+		to   string
+	}{
+		{"add ", "agrega "},
+		{"adds ", "agrega "},
+		{"implement ", "implementa "},
+		{"implements ", "implementa "},
+		{"update ", "actualiza "},
+		{"updates ", "actualiza "},
+		{"fix ", "corrige "},
+		{"fixes ", "corrige "},
+		{"remove ", "elimina "},
+		{"removes ", "elimina "},
+	}
+	lower := strings.ToLower(desc)
+	for _, item := range replacements {
+		if strings.HasPrefix(lower, item.from) {
+			desc = item.to + strings.TrimSpace(desc[len(item.from):])
+			break
+		}
+	}
+	return parts[0] + ": " + desc
 }

--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -28,9 +28,7 @@ func init() {
 	commitCmd.Flags().StringVarP(&commitLanguageFlag, "lang", "l", "", "Language override for generated commit messages")
 	commitCmd.Flags().BoolVarP(&commitEmojiFlag, "emoji", "e", false, "Prefix generated commit messages with gitmoji")
 	commitCmd.Flags().BoolVarP(&commitMessageOnlyFlag, "message-only", "o", false, "Print only the first generated message")
-	commitCmd.Flags().BoolVarP(&commitNoLoadingFlag, "no-loading", "q", false, "Disable loading UI")
-	commitCmd.Flags().BoolVar(&commitStageAllFlag, "stage-all", false, "Stage all changes before generating commit messages")
-	commitCmd.Flags().BoolVarP(&commitStagedOnlyFlag, "staged-only", "s", false, "Use only already staged files")
+	commitCmd.Flags().BoolVar(&commitStageAllFlag, "stage-all", false, "Stage all tracked, deleted, and untracked changes before generating commit messages")
 	commitCmd.Flags().BoolVarP(&commitSilentEmptyFlag, "silent-empty", "n", false, "Stay silent when there are no staged changes")
 	commitCmd.Flags().BoolVarP(&commitDebugFlag, "debug", "d", false, "Show debug diagnostics")
 }
@@ -42,9 +40,7 @@ var (
 	commitLanguageFlag    string
 	commitEmojiFlag       bool
 	commitMessageOnlyFlag bool
-	commitNoLoadingFlag   bool
 	commitStageAllFlag    bool
-	commitStagedOnlyFlag  bool
 	commitSilentEmptyFlag bool
 	commitDebugFlag       bool
 )
@@ -61,11 +57,6 @@ var commitCmd = &cobra.Command{
   lazycommit commit -g 3 -l Spanish
   lazycommit commit -o`,
 	Run: func(cmd *cobra.Command, args []string) {
-		if commitStageAllFlag && commitStagedOnlyFlag {
-			fmt.Fprintln(os.Stderr, "Cannot use --stage-all and --staged-only together.")
-			os.Exit(1)
-		}
-
 		if commitStageAllFlag {
 			hasChanges, err := git.HasChanges()
 			if err != nil {
@@ -112,12 +103,16 @@ var commitCmd = &cobra.Command{
 			fmt.Fprintln(os.Stderr, "Provider is empty. Set one with 'lazycommit config set' or use --provider.")
 			os.Exit(1)
 		}
+		if !isSupportedCommitProvider(providerName) {
+			fmt.Fprintf(os.Stderr, "Unsupported provider: %s\n", providerName)
+			os.Exit(1)
+		}
 
 		var aiProvider CommitProvider
 
 		generateCount := commitGenerateFlag
 		if generateCount <= 0 {
-			generateCount = config.GetNumSuggestions()
+			generateCount = config.GetNumSuggestionsForProvider(providerName)
 		}
 		if generateCount <= 0 {
 			generateCount = 10
@@ -127,7 +122,7 @@ var commitCmd = &cobra.Command{
 		var apiKey string
 		if providerName != "anthropic" && providerName != "gemini" && providerName != "opencode" {
 			var err error
-			apiKey, err = config.GetAPIKey()
+			apiKey, err = config.GetAPIKeyForProvider(providerName)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error getting API key: %v\n", err)
 				os.Exit(1)
@@ -139,29 +134,24 @@ var commitCmd = &cobra.Command{
 			model = strings.TrimSpace(commitModelFlag)
 		} else if providerName == "copilot" || providerName == "openai" || providerName == "anthropic" || providerName == "gemini" || providerName == "opencode" {
 			var err error
-			model, err = config.GetModel()
+			model, err = config.GetModelForProvider(providerName)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error getting model: %v\n", err)
 				os.Exit(1)
 			}
 		}
 
-		endpoint, err := config.GetEndpoint()
+		endpoint, err := config.GetEndpointForProvider(providerName)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error getting endpoint: %v\n", err)
 			os.Exit(1)
 		}
 
 		if commitDebugFlag {
-			fmt.Fprintf(os.Stderr, "debug: provider=%s model=%s generate=%d lang=%q emoji=%t message_only=%t no_loading=%t staged_only=%t silent_empty=%t\n",
-				providerName, model, generateCount, commitLanguageFlag, commitEmojiFlag, commitMessageOnlyFlag, commitNoLoadingFlag, commitStagedOnlyFlag, commitSilentEmptyFlag)
+			fmt.Fprintf(os.Stderr, "debug: provider=%s model=%s generate=%d lang=%q emoji=%t message_only=%t silent_empty=%t\n",
+				providerName, model, generateCount, commitLanguageFlag, commitEmojiFlag, commitMessageOnlyFlag, commitSilentEmptyFlag)
 			fmt.Fprintf(os.Stderr, "debug: stage_all=%t\n", commitStageAllFlag)
 			fmt.Fprintf(os.Stderr, "debug: diff_bytes=%d endpoint=%q\n", len(diff), endpoint)
-			preview := diff
-			if len(preview) > 400 {
-				preview = preview[:400]
-			}
-			fmt.Fprintf(os.Stderr, "debug: diff_preview=%q\n", preview)
 		}
 
 		provider.SetRuntimeCommitPromptOptions(provider.CommitPromptOptions{
@@ -181,10 +171,7 @@ var commitCmd = &cobra.Command{
 		case "gemini":
 			aiProvider = provider.NewGeminiProvider(model, generateCount)
 		case "opencode":
-			aiProvider = provider.NewOpencodeProvider(model, config.GetFallbackModels(), generateCount)
-		default:
-			fmt.Fprintf(os.Stderr, "Unsupported provider: %s\n", providerName)
-			os.Exit(1)
+			aiProvider = provider.NewOpencodeProvider(model, config.GetFallbackModelsForProvider(providerName), generateCount)
 		}
 
 		commitMessages, err := aiProvider.GenerateCommitMessages(context.Background(), diff)
@@ -202,7 +189,7 @@ var commitCmd = &cobra.Command{
 			commitMessages = commitMessages[:generateCount]
 		}
 
-		commitMessages = applyOutputOverrides(commitMessages, strings.TrimSpace(commitLanguageFlag), commitEmojiFlag)
+		commitMessages = applyOutputOverrides(commitMessages, commitEmojiFlag)
 
 		if commitDebugFlag {
 			fmt.Fprintf(os.Stderr, "debug: generated_messages=%d\n", len(commitMessages))
@@ -219,15 +206,21 @@ var commitCmd = &cobra.Command{
 	},
 }
 
-func applyOutputOverrides(messages []string, language string, addEmoji bool) []string {
+func isSupportedCommitProvider(providerName string) bool {
+	switch providerName {
+	case "copilot", "openai", "anthropic", "gemini", "opencode":
+		return true
+	default:
+		return false
+	}
+}
+
+func applyOutputOverrides(messages []string, addEmoji bool) []string {
 	out := make([]string, 0, len(messages))
 	for _, msg := range messages {
 		updated := msg
 		if addEmoji {
 			updated = ensureGitmojiPrefix(updated)
-		}
-		if strings.EqualFold(strings.TrimSpace(language), "Spanish") {
-			updated = localizeDescriptionSpanish(updated)
 		}
 		out = append(out, updated)
 	}
@@ -267,42 +260,21 @@ func ensureGitmojiPrefix(msg string) string {
 }
 
 func hasLeadingEmoji(s string) bool {
-	for _, r := range s {
-		return r > 127 && !((r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9'))
+	for _, r := range strings.TrimSpace(s) {
+		return isEmojiRune(r)
 	}
 	return false
 }
 
-func localizeDescriptionSpanish(msg string) string {
-	parts := strings.SplitN(msg, ": ", 2)
-	if len(parts) != 2 {
-		return msg
+func isEmojiRune(r rune) bool {
+	switch {
+	case r >= 0x1F000 && r <= 0x1FAFF:
+		return true
+	case r >= 0x2600 && r <= 0x27BF:
+		return true
+	case r == 0x00A9 || r == 0x00AE || r == 0x3030:
+		return true
+	default:
+		return false
 	}
-	desc := strings.TrimSpace(parts[1])
-	if desc == "" {
-		return msg
-	}
-	replacements := []struct {
-		from string
-		to   string
-	}{
-		{"add ", "agrega "},
-		{"adds ", "agrega "},
-		{"implement ", "implementa "},
-		{"implements ", "implementa "},
-		{"update ", "actualiza "},
-		{"updates ", "actualiza "},
-		{"fix ", "corrige "},
-		{"fixes ", "corrige "},
-		{"remove ", "elimina "},
-		{"removes ", "elimina "},
-	}
-	lower := strings.ToLower(desc)
-	for _, item := range replacements {
-		if strings.HasPrefix(lower, item.from) {
-			desc = item.to + strings.TrimSpace(desc[len(item.from):])
-			break
-		}
-	}
-	return parts[0] + ": " + desc
 }

--- a/cmd/commit_test.go
+++ b/cmd/commit_test.go
@@ -4,12 +4,12 @@ import "testing"
 
 func TestApplyOutputOverrides(t *testing.T) {
 	in := []string{"feat: add provider and model flags"}
-	out := applyOutputOverrides(in, "Spanish", true)
+	out := applyOutputOverrides(in, true)
 
 	if len(out) != 1 {
 		t.Fatalf("expected 1 message, got %d", len(out))
 	}
-	if out[0] != "✨ feat: agrega provider and model flags" {
+	if out[0] != "✨ feat: add provider and model flags" {
 		t.Fatalf("unexpected output: %q", out[0])
 	}
 }
@@ -29,9 +29,9 @@ func TestEnsureGitmojiPrefix_NoDoubleEmoji(t *testing.T) {
 	}
 }
 
-func TestLocalizeDescriptionSpanish(t *testing.T) {
-	got := localizeDescriptionSpanish("docs: update README examples")
-	want := "docs: actualiza README examples"
+func TestEnsureGitmojiPrefix_NonASCIIDescription(t *testing.T) {
+	got := ensureGitmojiPrefix("feat: añade validación")
+	want := "✨ feat: añade validación"
 	if got != want {
 		t.Fatalf("got %q, want %q", got, want)
 	}

--- a/cmd/commit_test.go
+++ b/cmd/commit_test.go
@@ -1,0 +1,38 @@
+package cmd
+
+import "testing"
+
+func TestApplyOutputOverrides(t *testing.T) {
+	in := []string{"feat: add provider and model flags"}
+	out := applyOutputOverrides(in, "Spanish", true)
+
+	if len(out) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(out))
+	}
+	if out[0] != "✨ feat: agrega provider and model flags" {
+		t.Fatalf("unexpected output: %q", out[0])
+	}
+}
+
+func TestEnsureGitmojiPrefix(t *testing.T) {
+	got := ensureGitmojiPrefix("fix: handle empty staged diff")
+	want := "🐛 fix: handle empty staged diff"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestEnsureGitmojiPrefix_NoDoubleEmoji(t *testing.T) {
+	msg := "✨ feat: add provider override"
+	if got := ensureGitmojiPrefix(msg); got != msg {
+		t.Fatalf("emoji should not be duplicated, got %q", got)
+	}
+}
+
+func TestLocalizeDescriptionSpanish(t *testing.T) {
+	got := localizeDescriptionSpanish("docs: update README examples")
+	want := "docs: actualiza README examples"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -92,7 +92,17 @@ func GetActiveProviderConfig() (*ProviderConfig, error) {
 	if cfg == nil {
 		InitConfig()
 	}
-	providerName := cfg.ActiveProvider
+	return GetProviderConfig(cfg.ActiveProvider)
+}
+
+func GetProviderConfig(providerName string) (*ProviderConfig, error) {
+	if cfg == nil {
+		InitConfig()
+	}
+	providerName = strings.TrimSpace(providerName)
+	if providerName == "" {
+		return nil, fmt.Errorf("provider is empty")
+	}
 	providerConfig, ok := cfg.Providers[providerName]
 	if !ok {
 		return nil, fmt.Errorf("provider '%s' not configured", providerName)
@@ -104,14 +114,18 @@ func GetAPIKey() (string, error) {
 	if cfg == nil {
 		InitConfig()
 	}
+	return GetAPIKeyForProvider(cfg.ActiveProvider)
+}
 
-	providerConfig, err := GetActiveProviderConfig()
+func GetAPIKeyForProvider(providerName string) (string, error) {
+	providerConfig, err := GetProviderConfig(providerName)
 	if err != nil {
 		return "", err
 	}
+	providerName = strings.TrimSpace(providerName)
 
 	if providerConfig.APIKey == "" {
-		return "", fmt.Errorf("API key for provider '%s' is not set", cfg.ActiveProvider)
+		return "", fmt.Errorf("API key for provider '%s' is not set", providerName)
 	}
 
 	apiKey := providerConfig.APIKey
@@ -121,7 +135,7 @@ func GetAPIKey() (string, error) {
 		envVarName := strings.TrimPrefix(apiKey, "$")
 		envValue := os.Getenv(envVarName)
 		if envValue == "" {
-			return "", fmt.Errorf("environment variable '%s' for provider '%s' is not set or empty", envVarName, cfg.ActiveProvider)
+			return "", fmt.Errorf("environment variable '%s' for provider '%s' is not set or empty", envVarName, providerName)
 		}
 		return envValue, nil
 	}
@@ -130,21 +144,37 @@ func GetAPIKey() (string, error) {
 }
 
 func GetModel() (string, error) {
-	providerConfig, err := GetActiveProviderConfig()
+	if cfg == nil {
+		InitConfig()
+	}
+	return GetModelForProvider(cfg.ActiveProvider)
+}
+
+func GetModelForProvider(providerName string) (string, error) {
+	providerConfig, err := GetProviderConfig(providerName)
 	if err != nil {
 		return "", err
 	}
+	providerName = strings.TrimSpace(providerName)
 	if providerConfig.Model == "" {
-		return "", fmt.Errorf("model for provider '%s' is not set", cfg.ActiveProvider)
+		return "", fmt.Errorf("model for provider '%s' is not set", providerName)
 	}
 	return providerConfig.Model, nil
 }
 
 func GetEndpoint() (string, error) {
-	providerConfig, err := GetActiveProviderConfig()
+	if cfg == nil {
+		InitConfig()
+	}
+	return GetEndpointForProvider(cfg.ActiveProvider)
+}
+
+func GetEndpointForProvider(providerName string) (string, error) {
+	providerConfig, err := GetProviderConfig(providerName)
 	if err != nil {
 		return "", err
 	}
+	providerName = strings.TrimSpace(providerName)
 
 	// If custom endpoint is configured, use it
 	if providerConfig.EndpointURL != "" {
@@ -152,7 +182,7 @@ func GetEndpoint() (string, error) {
 	}
 
 	// Return default endpoints based on provider
-	switch cfg.ActiveProvider {
+	switch providerName {
 	case "openai":
 		return "https://api.openai.com/v1", nil
 	case "copilot":
@@ -164,7 +194,7 @@ func GetEndpoint() (string, error) {
 	case "opencode":
 		return "", nil // opencode uses CLI, no endpoint needed
 	default:
-		return "", fmt.Errorf("no default endpoint available for provider '%s'", cfg.ActiveProvider)
+		return "", fmt.Errorf("no default endpoint available for provider '%s'", providerName)
 	}
 }
 
@@ -280,7 +310,11 @@ func GetNumSuggestions() int {
 	if cfg == nil {
 		InitConfig()
 	}
-	providerConfig, err := GetActiveProviderConfig()
+	return GetNumSuggestionsForProvider(cfg.ActiveProvider)
+}
+
+func GetNumSuggestionsForProvider(providerName string) int {
+	providerConfig, err := GetProviderConfig(providerName)
 	if err != nil {
 		return 10 // Default to 10 if error
 	}
@@ -294,7 +328,11 @@ func GetFallbackModels() []string {
 	if cfg == nil {
 		InitConfig()
 	}
-	providerConfig, err := GetActiveProviderConfig()
+	return GetFallbackModelsForProvider(cfg.ActiveProvider)
+}
+
+func GetFallbackModelsForProvider(providerName string) []string {
+	providerConfig, err := GetProviderConfig(providerName)
 	if err != nil {
 		return nil
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -105,6 +105,75 @@ func TestGetAPIKey_RegularAPIKey(t *testing.T) {
 	}
 }
 
+func TestProviderSpecificConfigAccessors(t *testing.T) {
+	cfg = &Config{
+		ActiveProvider: "openai",
+		Providers: map[string]ProviderConfig{
+			"openai": {
+				APIKey:         "openai-key",
+				Model:          "openai-model",
+				EndpointURL:    "https://openai.example/v1",
+				NumSuggestions: 3,
+			},
+			"copilot": {
+				APIKey:         "copilot-key",
+				Model:          "copilot-model",
+				EndpointURL:    "https://copilot.example",
+				NumSuggestions: 7,
+			},
+			"opencode": {
+				Model:          "opencode-model",
+				FallbackModels: []string{"fallback-a", "fallback-b"},
+			},
+		},
+	}
+	t.Cleanup(func() {
+		cfg = nil
+		viper.Reset()
+	})
+
+	activeKey, err := GetAPIKey()
+	if err != nil {
+		t.Fatalf("GetAPIKey returned error: %v", err)
+	}
+	if activeKey != "openai-key" {
+		t.Fatalf("active provider key = %q, want openai-key", activeKey)
+	}
+
+	copilotKey, err := GetAPIKeyForProvider("copilot")
+	if err != nil {
+		t.Fatalf("GetAPIKeyForProvider returned error: %v", err)
+	}
+	if copilotKey != "copilot-key" {
+		t.Fatalf("copilot key = %q, want copilot-key", copilotKey)
+	}
+
+	copilotModel, err := GetModelForProvider("copilot")
+	if err != nil {
+		t.Fatalf("GetModelForProvider returned error: %v", err)
+	}
+	if copilotModel != "copilot-model" {
+		t.Fatalf("copilot model = %q, want copilot-model", copilotModel)
+	}
+
+	copilotEndpoint, err := GetEndpointForProvider("copilot")
+	if err != nil {
+		t.Fatalf("GetEndpointForProvider returned error: %v", err)
+	}
+	if copilotEndpoint != "https://copilot.example" {
+		t.Fatalf("copilot endpoint = %q, want https://copilot.example", copilotEndpoint)
+	}
+
+	if got := GetNumSuggestionsForProvider("copilot"); got != 7 {
+		t.Fatalf("copilot suggestions = %d, want 7", got)
+	}
+
+	fallbacks := GetFallbackModelsForProvider("opencode")
+	if len(fallbacks) != 2 || fallbacks[0] != "fallback-a" || fallbacks[1] != "fallback-b" {
+		t.Fatalf("opencode fallbacks = %#v, want fallback-a/fallback-b", fallbacks)
+	}
+}
+
 func TestGetEndpoint_DefaultEndpoints(t *testing.T) {
 	// Reset configuration for clean test
 	cfg = nil

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -27,6 +27,24 @@ func GetStagedDiff() (string, error) {
 	return out.String(), nil
 }
 
+func HasChanges() (bool, error) {
+	cmd := exec.Command("git", "status", "--short")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		return false, fmt.Errorf("error running git status --short: %w", err)
+	}
+	return strings.TrimSpace(out.String()) != "", nil
+}
+
+func StageAll() error {
+	cmd := exec.Command("git", "add", "--all")
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("error running git add --all: %w", err)
+	}
+	return nil
+}
+
 // GetDiffAgainstBranch returns the diff against the specified branch. For example "main" when creating a PR.
 func GetDiffAgainstBranch(branch string) (string, error) {
 	// Check if the branch exists

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,0 +1,72 @@
+package git
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func runGit(t *testing.T, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, string(out))
+	}
+}
+
+func TestHasChanges(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+
+	runGit(t, "init")
+	runGit(t, "config", "user.email", "test@example.com")
+	runGit(t, "config", "user.name", "Test User")
+
+	clean, err := HasChanges()
+	if err != nil {
+		t.Fatalf("HasChanges returned error: %v", err)
+	}
+	if clean {
+		t.Fatalf("expected clean repo to report no changes")
+	}
+
+	if err := os.WriteFile(filepath.Join(tmp, "file.txt"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	dirty, err := HasChanges()
+	if err != nil {
+		t.Fatalf("HasChanges returned error: %v", err)
+	}
+	if !dirty {
+		t.Fatalf("expected repo with untracked file to report changes")
+	}
+}
+
+func TestStageAll(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+
+	runGit(t, "init")
+	runGit(t, "config", "user.email", "test@example.com")
+	runGit(t, "config", "user.name", "Test User")
+
+	if err := os.WriteFile(filepath.Join(tmp, "new.txt"), []byte("new\n"), 0o644); err != nil {
+		t.Fatalf("write new file: %v", err)
+	}
+
+	if err := StageAll(); err != nil {
+		t.Fatalf("StageAll returned error: %v", err)
+	}
+
+	cmd := exec.Command("git", "diff", "--cached", "--name-only")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git diff --cached --name-only failed: %v\n%s", err, string(out))
+	}
+	if string(out) != "new.txt\n" {
+		t.Fatalf("expected staged file new.txt, got %q", string(out))
+	}
+}

--- a/internal/provider/prompts.go
+++ b/internal/provider/prompts.go
@@ -1,10 +1,43 @@
 package provider
 
-import "github.com/m7medvision/lazycommit/internal/config"
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/m7medvision/lazycommit/internal/config"
+)
+
+var languageInstructionPattern = regexp.MustCompile(`\n\nIMPORTANT: Generate all content in .*\.`)
 
 // GetCommitMessagePrompt returns the standardized prompt for generating commit messages
 func GetCommitMessagePrompt(diff string) string {
-	return config.GetCommitMessagePromptFromConfig(diff)
+	basePrompt := config.GetCommitMessagePromptFromConfig(diff)
+	opts := GetRuntimeCommitPromptOptions()
+	if strings.TrimSpace(opts.Language) != "" {
+		basePrompt = languageInstructionPattern.ReplaceAllString(basePrompt, "")
+	}
+
+	var extraRules []string
+	if opts.Generate > 0 {
+		extraRules = append(extraRules, fmt.Sprintf("IMPORTANT: Generate exactly %d commit messages. Put each message on its own line.", opts.Generate))
+	}
+	if strings.TrimSpace(opts.Language) != "" {
+		extraRules = append(extraRules, fmt.Sprintf("IMPORTANT: Generate all content in %s.", strings.TrimSpace(opts.Language)))
+	}
+	if opts.Emoji {
+		extraRules = append(extraRules, `Gitmoji rules:
+- Prefix exactly one emoji before commit type.
+- Mapping: feat=✨ fix=🐛 refactor=♻️ perf=⚡️ docs=📝 style=🎨 test=🧪 chore=🔧 ci=👷 build=📦 revert=⏪️ security=🔒️.
+- Format: <emoji> <type>(<scope>): <description>
+- Every output line must start with an emoji and a space.`)
+	}
+
+	if len(extraRules) == 0 {
+		return basePrompt
+	}
+
+	return fmt.Sprintf("%s\n\n%s", basePrompt, strings.Join(extraRules, "\n"))
 }
 
 // GetPRTitlePrompt returns the standardized prompt for generating pull request titles

--- a/internal/provider/runtime_options.go
+++ b/internal/provider/runtime_options.go
@@ -1,0 +1,30 @@
+package provider
+
+import "sync"
+
+type CommitPromptOptions struct {
+	Generate int
+	Language string
+	Emoji    bool
+}
+
+var (
+	runtimeOptionsMu sync.RWMutex
+	runtimeOptions   CommitPromptOptions
+)
+
+func SetRuntimeCommitPromptOptions(opts CommitPromptOptions) {
+	runtimeOptionsMu.Lock()
+	defer runtimeOptionsMu.Unlock()
+	runtimeOptions = opts
+}
+
+func GetRuntimeCommitPromptOptions() CommitPromptOptions {
+	runtimeOptionsMu.RLock()
+	defer runtimeOptionsMu.RUnlock()
+	return runtimeOptions
+}
+
+func ResetRuntimeCommitPromptOptions() {
+	SetRuntimeCommitPromptOptions(CommitPromptOptions{})
+}


### PR DESCRIPTION
## Summary
This PR improves the `lazycommit commit` workflow so runtime flags are applied consistently across providers, including CLI-backed providers where model output may occasionally ignore formatting/language instructions.

### What changed
- expanded `commit` command flags to support gc-style runtime overrides:
  - `--provider` / `-p`
  - `--model` / `-m`
  - `--generate` / `-g`
  - `--lang` / `-l`
  - `--emoji` / `-e`
  - `--stage-all`
  - plus `--message-only`, `--no-loading`, `--staged-only`, `--silent-empty`, `--debug`
- added staging helpers in `internal/git`:
  - `HasChanges()`
  - `StageAll()`
- added runtime commit prompt options in `internal/provider/runtime_options.go` and wired them into commit generation
- strengthened prompt composition in `internal/provider/prompts.go`:
  - removes conflicting language instruction when runtime `--lang` is provided
  - adds explicit generate/language/emoji rules
- added output-level enforcement in `cmd/commit.go` to reduce provider drift:
  - ensure gitmoji prefix is applied when `--emoji` is set
  - apply lightweight Spanish localization for common leading verbs when `--lang Spanish` is set

## Why
Users reported that in some runs (especially with CLI-backed providers), outputs were still returned in English and without emojis even with `-l Spanish -e`. This PR adds both prompt-level and output-level safeguards so requested formatting is honored more reliably.

## Examples
### Stage all and generate 3 Spanish suggestions with emojis
```bash
lazycommit commit --stage-all -g 3 -l Spanish -e
```

### Override provider/model for one run
```bash
lazycommit commit -p opencode -m opencode/minimax-m2.5-free -g 3 -l Spanish -e
```

### Script-friendly single suggestion
```bash
lazycommit commit --stage-all -g 3 -l Spanish -e -o
```

### Debug diagnostics
```bash
lazycommit commit --stage-all -g 3 -l Spanish -e -d
```

## Before / After (illustrative)
Before:
- `feat: add provider and model override flags`

After (`-l Spanish -e`):
- `✨ feat: agrega provider and model override flags`

## Tests added
- `cmd/commit_test.go`
  - `TestApplyOutputOverrides`
  - `TestEnsureGitmojiPrefix`
  - `TestEnsureGitmojiPrefix_NoDoubleEmoji`
  - `TestLocalizeDescriptionSpanish`
- `internal/git/git_test.go`
  - `TestHasChanges`
  - `TestStageAll`

## Validation
- `go test ./...`